### PR TITLE
Fix support for NextJS

### DIFF
--- a/packages/dapp-kit/src/constants/certificates.ts
+++ b/packages/dapp-kit/src/constants/certificates.ts
@@ -2,7 +2,9 @@ const DEFAULT_CONNECT_CERT_MESSAGE: Connex.Vendor.CertMessage = {
     purpose: 'identification',
     payload: {
         type: 'text',
-        content: `The following dApp would like to see your public address: ${window.origin}`,
+        content: `The following dApp would like to see your public address: ${
+            typeof window !== 'undefined' ? window.origin : ''
+        }`,
     },
 };
 


### PR DESCRIPTION
By accessing `window.origin` in a static file, `NextJS` complains about the fact that `window` is not defined server-side.
This will allow the kit to not throw any errors related to the kit itself.