### PR TITLE
fix: add license to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "vechain-dapp-kit",
     "private": true,
     "description": "A TypeScript library that facilitates seamless interaction between vechain wallets (veworld, sync2) and dApps.",
+    "license": "MIT",
     "workspaces": [
         "examples/*",
         "packages/*",

--- a/packages/dapp-kit/package.json
+++ b/packages/dapp-kit/package.json
@@ -7,6 +7,7 @@
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "license": "MIT",
     "files": [
         "dist",
         "package.json",


### PR DESCRIPTION
Socket scan is giving a 0 score to the "license" field as in the picture:
<img width="1179" alt="image" src="https://github.com/vechain/vechain-dapp-kit/assets/73019897/28b592c4-7a06-41c3-9356-06ae82843b0e">
This PR fixes this problem.