### PR TITLE
chore: add test-testid

### DIFF
--- a/packages/dapp-kit-ui/src/components/modals/address-modal.ts
+++ b/packages/dapp-kit-ui/src/components/modals/address-modal.ts
@@ -200,6 +200,7 @@ export class AddressModal extends LitElement {
                     <button
                             class="${this.mode}"
                             @click=${this.onDisconnectClick}
+                            data-testid="Disconnect"
                     >
                         <div class="disconnect-icon ${this.mode}">
                             ${

--- a/packages/dapp-kit-ui/src/components/modals/connect-modal/source-card.ts
+++ b/packages/dapp-kit-ui/src/components/modals/connect-modal/source-card.ts
@@ -49,6 +49,7 @@ export class SourceCard extends LitElement {
             <button
                 class="card ${this.mode}"
                 @click=${(): void => this.handleSourceClick()}
+                data-testid="${this.source?.name}"
             >
                 <div>${this.source?.name}</div>
                 <img src=${this.source?.logo} />


### PR DESCRIPTION
Add data-testid on source-card component and also disconnect button
Tools like playwright can query the shadow dom on this attribute and easily click on VeWorld for example

fixes: #220 

reference: https://playwright.dev/docs/locators#locate-in-shadow-dom