### PR TITLE
Fix VeWorld v1/v2 API mode handling

### DIFF
--- a/examples/sample-next-app/src/app/globals.css
+++ b/examples/sample-next-app/src/app/globals.css
@@ -21,3 +21,9 @@ h2 {
     margin-top: 20px;
     margin-bottom: 10px;
 }
+.api-toggle {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-top: 16px;
+}

--- a/examples/sample-next-app/src/app/pages/homepage.tsx
+++ b/examples/sample-next-app/src/app/pages/homepage.tsx
@@ -12,7 +12,8 @@ const Button = (): ReactElement => {
     const { account, signer } = useWallet();
     const { open, onConnectionStatusChange } = useWalletModal();
     const [buttonText, setButtonText] = useState('Connect Custom Button');
-    const { onConnectRequest } = useDappKitFunctions();
+    const { onConnectRequest, setV2ApiEnabled, v2ApiEnabled } =
+        useDappKitFunctions();
 
     const sendTx = () =>
         signer?.sendTransaction({
@@ -101,6 +102,17 @@ const Button = (): ReactElement => {
     return (
         <div className="container">
             <h2>Next JS</h2>
+            <label className="api-toggle">
+                <span>API mode</span>
+                <input
+                    checked={v2ApiEnabled}
+                    onChange={(event) =>
+                        setV2ApiEnabled(event.currentTarget.checked)
+                    }
+                    type="checkbox"
+                />
+                <span>{v2ApiEnabled ? 'v2 enabled' : 'v1'}</span>
+            </label>
             <div className="label">kit button:</div>
             <WalletButton />
             <div className="label">custom button:</div>

--- a/examples/sample-next-app/src/providers/provider.tsx
+++ b/examples/sample-next-app/src/providers/provider.tsx
@@ -13,6 +13,7 @@ import {
     useContext,
     useMemo,
     useRef,
+    useState,
 } from 'react';
 
 const walletConnectOptions: WalletConnectOptions = {
@@ -39,24 +40,31 @@ type OnConnectResponse = NonNullable<
 type ContextProps = {
     onConnectRequest: RefObject<OnConnectRequest | null>;
     onConnectResponse: RefObject<OnConnectResponse | null>;
+    v2ApiEnabled: boolean;
+    setV2ApiEnabled: (enabled: boolean) => void;
 };
 
 //This context has been created only for display purposes. It's not needed to created something like this
 const FunctionContext = createContext<ContextProps>({
     onConnectRequest: createRef(),
     onConnectResponse: createRef(),
+    v2ApiEnabled: false,
+    setV2ApiEnabled: () => undefined,
 });
 
 export const Provider = ({ children }: PropsWithChildren) => {
     const onConnectRequestRef = useRef<OnConnectRequest>(null);
     const onConnectResponseRef = useRef<OnConnectResponse>(null);
+    const [v2ApiEnabled, setV2ApiEnabled] = useState(false);
 
     const ctxValue = useMemo(
         () => ({
             onConnectRequest: onConnectRequestRef,
             onConnectResponse: onConnectResponseRef,
+            v2ApiEnabled,
+            setV2ApiEnabled,
         }),
-        [],
+        [v2ApiEnabled],
     );
 
     const onConnectRequest = useCallback<OnConnectRequest>((source) => {
@@ -82,7 +90,11 @@ export const Provider = ({ children }: PropsWithChildren) => {
                 usePersistence
                 walletConnectOptions={walletConnectOptions}
                 logLevel={'DEBUG'}
-                v2Api={{ enabled: true, onConnectRequest, onConnectResponse }}
+                v2Api={{
+                    enabled: v2ApiEnabled,
+                    onConnectRequest,
+                    onConnectResponse,
+                }}
             >
                 {children}
             </DAppKitProvider>

--- a/packages/dapp-kit-ui/src/components/modals/address-modal.ts
+++ b/packages/dapp-kit-ui/src/components/modals/address-modal.ts
@@ -313,9 +313,14 @@ export class AddressModal extends LitElement {
         );
     }
 
+    private get v2ApiEnabled(): boolean {
+        return DAppKitUI.get().options.v2Api.enabled ?? false;
+    }
+
     private get showAccountManager(): boolean {
         return (
             this.source === 'veworld' &&
+            this.v2ApiEnabled &&
             this.showInlineAccounts &&
             (this.addresses.length > 1 || this.canAddAccount)
         );

--- a/packages/dapp-kit-ui/test/address-modal.test.ts
+++ b/packages/dapp-kit-ui/test/address-modal.test.ts
@@ -79,6 +79,29 @@ describe('vdk-address-modal account manager', () => {
         expect(onAddAccount).toHaveBeenCalled();
     });
 
+    it('does not render the account manager when v2Api is disabled', async () => {
+        DAppKitUI.configure({
+            node: 'https://mainnet.vechain.org/',
+            v2Api: { enabled: false },
+        });
+        const modal = createAddressModal();
+        modal.source = 'veworld';
+        modal.availableMethods = [
+            'wallet_requestPermissions',
+            'wallet_revokeAccountPermission',
+        ];
+        modal.addresses = [ACCOUNT_A, ACCOUNT_B];
+        await modal.updateComplete;
+
+        const cards = modal.shadowRoot?.querySelectorAll('vdk-account-card');
+        expect(cards?.length ?? 0).toBe(0);
+
+        const addButton = modal.shadowRoot?.querySelector(
+            'button[data-testid="Change connected accounts"]',
+        );
+        expect(addButton).toBeNull();
+    });
+
     it('does not render the account manager for non-VeWorld wallets', async () => {
         const modal = createAddressModal();
         modal.source = 'wallet-connect';

--- a/packages/dapp-kit-ui/test/connect-modal.test.ts
+++ b/packages/dapp-kit-ui/test/connect-modal.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectModal, DAppKitUI, type SourceInfo } from '../src';
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111';
+const VEWORLD_SOURCE = { id: 'veworld' } as SourceInfo;
+
+const createConnectModal = (): ConnectModal => {
+    const modal = window.document.createElement(
+        'vdk-connect-modal',
+    ) as ConnectModal;
+    window.document.body.appendChild(modal);
+    return modal;
+};
+
+describe('vdk-connect-modal', () => {
+    beforeEach(() => {
+        window.document.body.innerHTML = '';
+        Object.defineProperty(window, 'vechain', {
+            configurable: true,
+            value: { isInAppBrowser: false },
+        });
+        DAppKitUI.configure({
+            node: 'https://mainnet.vechain.org/',
+            v2Api: { enabled: false },
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        Object.defineProperty(window, 'vechain', {
+            configurable: true,
+            value: undefined,
+        });
+    });
+
+    it('uses the certificate connection flow when v2Api is disabled', async () => {
+        const modal = createConnectModal();
+        const connect = vi
+            .spyOn(DAppKitUI.wallet, 'connect')
+            .mockResolvedValue({ account: ACCOUNT, verified: true });
+        const connectV2 = vi.spyOn(DAppKitUI.wallet, 'connectV2');
+
+        modal.onSourceClick(VEWORLD_SOURCE);
+        await new Promise((resolve) => setTimeout(resolve));
+        await modal.updateComplete;
+
+        expect(connect).toHaveBeenCalledOnce();
+        expect(connectV2).not.toHaveBeenCalled();
+        expect(modal.requestForConnectionCertificate).toBe(true);
+        expect(
+            modal.shadowRoot?.querySelector('vdk-sign-connection-certificate'),
+        ).toBeTruthy();
+    });
+});

--- a/packages/dapp-kit/src/utils/create-wallet.ts
+++ b/packages/dapp-kit/src/utils/create-wallet.ts
@@ -26,6 +26,7 @@ export const createWallet = async ({
     walletConnectOptions,
     onDisconnected,
     connectionCertificate,
+    v2Api,
 }: ICreateWallet): Promise<VeChainWallet> => {
     DAppKitLogger.debug('createWallet', source);
 
@@ -63,19 +64,19 @@ export const createWallet = async ({
                     throw new Error('VeWorld Extension is not installed');
                 }
 
-                // Prefer the v2 EIP-1193-style `request` API when the extension
-                // exposes it. This avoids the legacy certificate-based connect
-                // and keeps subsequent signing on the v2 channel
-                // (`thor_signCertificate`, `thor_signTypedData`,
-                // `thor_sendTransaction`), which VeWorld would otherwise reject
-                // for a v2-connected app.
+                // Prefer the v2 EIP-1193-style `request` API only when the app
+                // explicitly enables v2. Otherwise keep the legacy
+                // certificate-based connection flow.
                 const ext = window.vechain as unknown as {
                     request?: (args: {
                         method: string;
                         params?: unknown;
                     }) => Promise<unknown>;
                 };
-                if (typeof ext.request === 'function') {
+                if (
+                    v2Api?.enabled !== false &&
+                    typeof ext.request === 'function'
+                ) {
                     const { walletSigner, walletProvider } =
                         createVeWorldV2Wallet(ext.request.bind(ext), genesisId);
                     return new CertificateBasedWallet(

--- a/packages/dapp-kit/test/create-wallet.test.ts
+++ b/packages/dapp-kit/test/create-wallet.test.ts
@@ -17,6 +17,7 @@ type ICreateWallet = DAppKitOptions & {
 const createOptions = (
     source: WalletSource,
     wcOptions?: WalletConnectOptions,
+    v2ApiEnabled = true,
 ): ICreateWallet => {
     return {
         node: mockedHttpClient.baseURL,
@@ -25,7 +26,7 @@ const createOptions = (
         onDisconnected: () => {},
         thor: new ThorClient(mockedHttpClient),
         v2Api: {
-            enabled: true,
+            enabled: v2ApiEnabled,
         },
     };
 };
@@ -50,6 +51,19 @@ describe('createWallet', () => {
             const wallet = await createWallet(createOptions('veworld'));
 
             expect(wallet).toBeDefined();
+        });
+
+        it('uses the legacy signer when v2Api is disabled', async () => {
+            window.vechain = {
+                request: vi.fn(),
+                newConnexSigner: () => ({}) as WalletSigner,
+            };
+
+            const wallet = await createWallet(
+                createOptions('veworld', undefined, false),
+            );
+
+            await expect(wallet.getAvailableMethods()).resolves.toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary
- Keep VeWorld on the legacy certificate flow when `v2Api.enabled` is false, even if the extension exposes the v2 request API.
- Hide the multi-account manager in the connected account modal when v2 API is disabled.
- Add a sample Next app toggle to switch between v1 and v2 while testing.

## Test plan
- `yarn workspace @vechain/dapp-kit test create-wallet.test.ts`
- `yarn workspace @vechain/dapp-kit-ui test connect-modal.test.ts address-modal.test.ts`
- `yarn workspace sample-next-app build`